### PR TITLE
Run CI with multiple Node versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,16 @@
 version: 2
 jobs:
-  test:
+  test_with_node6: &test_with_node6
     docker:
-      - image: node:8
+      - image: node:6
+        environment:
+          NODE_VERSION: 6
     steps:
       - checkout
 
       - restore_cache:
           keys:
-            - yarn-{{ checksum "yarn.lock" }}
+            - yarn-{{ checksum "yarn.lock" }}-{{ .Environment.NODE_VERSION }}
             - yarn-
 
       - run:
@@ -20,12 +22,28 @@ jobs:
           command: yarn test
 
       - save_cache:
-          key: yarn-{{ checksum "yarn.lock" }}
+          key: yarn-{{ checksum "yarn.lock" }}-{{ .Environment.NODE_VERSION }}
           paths:
             - ~/.cache/yarn
+
+  test_with_node8:
+    <<: *test_with_node6
+    docker:
+      - image: node:8
+        environment:
+          NODE_VERSION: 8
+
+  test_with_node9:
+    <<: *test_with_node6
+    docker:
+      - image: node:9
+        environment:
+          NODE_VERSION: 9
 
 workflows:
   version: 2
   build_and_test:
     jobs:
-      - test
+      - test_with_node6
+      - test_with_node8
+      - test_with_node9


### PR DESCRIPTION
Resolves #7 

https://circleci.com/workflow-run/a31018d5-bdd0-4d0e-bc97-4b14254ce50b
![image](https://user-images.githubusercontent.com/21182617/41883306-c75011cc-78a2-11e8-84bf-b6eba841c059.png)

I knew the lib fails with Node 10 by depending libraries, so created #10 to work separately.

```
#!/bin/bash -eo pipefail
yarn install --cache-folder ~/.cache/yarn
yarn install v1.7.0
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
(node:72) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
error upath@1.0.4: The engine "node" is incompatible with this module. Expected version ">=4 <=9".
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Exited with code 1
```